### PR TITLE
Travis CIでCI設定を追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+
+node_js:
+  - node
+
+os: linux
+
+dist: bionic
+
+cache: yarn
+
+install:
+  - yarn install
+
+script:
+  - yarn lint
+  - yarn build


### PR DESCRIPTION
- Travis CIの設定を追加
    - サンプルの実行結果: https://travis-ci.com/github/y-yu/Dasshoku/jobs/336958929
    - 多少の`warnings`がでてる……🤔

    ```
    -  Building for production...
    (node:8203) Warning: Accessing non-existent property 'lineno' of module exports inside circular dependency
    (Use `node --trace-warnings ...` to show where the warning was created)
    (node:8203) Warning: Accessing non-existent property 'column' of module exports inside circular dependency
    (node:8203) Warning: Accessing non-existent property 'filename' of module exports inside circular dependency
    (node:8203) Warning: Accessing non-existent property 'lineno' of module exports inside circular dependency
    (node:8203) Warning: Accessing non-existent property 'column' of module exports inside circular dependency
    (node:8203) Warning: Accessing non-existent property 'filename' of module exports inside circular dependency
    ```

### このPRのマージ後にやること

1. https://travis-ci.com へ行きGitHubでログイン
    - `travis-ci.com`に行くこと！`travis-ci.org`は古いやつなので使ってはならない……
2. OAuth連携すると、次のコミットから勝手にやってくれる