### PR TITLE
[WIP] masterブランチのCI後にgh-pagesへ自動デプロイする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ install:
 script:
   - yarn lint
   - yarn build
+
+after_success:
+  - ./.travis/deploy_gh-pages.sh

--- a/.travis/deploy_gh-pages.sh
+++ b/.travis/deploy_gh-pages.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+if [[ "${TRAVIS_OS_NAME}" == "linux" && "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
+  echo -e "Host github.com\n\tStrictHostKeyChecking no\nIdentityFile ~/.ssh/deploy.key\n" >> ~/.ssh/config
+  openssl aes-256-cbc -pass "pass:$SERVER_KEY" -pbkdf2 -in ./.travis/deploy_key.enc -d -a -out deploy.key
+  cp deploy.key ~/.ssh/
+  chmod 600 ~/.ssh/deploy.key
+  git config --global user.email "vienosnotes@gmail.com"
+  git config --global user.name "VienosNotes"
+  git fetch origin gh-pages:gh-pages
+  sudo git stash -u
+  sudo git checkout gh-pages
+  sudo git stash pop
+  sudo git add .
+  sudo git commit -a -m "auto commit on travis $TRAVIS_JOB_NUMBER $TRAVIS_COMMIT"
+  git push git@github.com:VienosNotes/Dasshoku.git gh-pages:gh-pages
+fi
+


### PR DESCRIPTION
- `yarn build`した後に成功したら（`after_success`）自動で`gh-pages`ブランチに`git push`するスクリプトを追加した
- そもそも、こういうものが必要なのか？というのがあるのでそういう議論も 🙆‍♂️ 
- ただし、これを使うには必要なことがある
    1. `ssh-keygen`で`deploy_key`作成して、公開鍵の方をこのリポジトリーの`Deploy Keys`に登録する
    2. 秘密鍵を`openssl`で暗号化して、暗号ファイルを`./.travis`フォルダーに置く
    3. Travis CIに（2）で使った暗号用のパスワードを登録する
- こうすることで、`deploy_gh-pages.sh`では 👇 こういうことが行なわれる
    1. ブランチが`master`かどうかなどを判定
    2. 暗号化されたSSH秘密鍵を復号（これはTravis CIの秘密環境変数なので、Webコンソールに表示されない）してTravis CI上のホームフォルダーに設置してパーミッションを設定
    3. Gitをいい感じに設定
    4. `git add`して`git commit`など
    5. `gh-pages`ブランチへ`git push`する
- 手順として参考になるのが下記にある
    - https://blog.eiel.info/blog/2014/02/18/github-push-from-travis/
        - ただし、`bionic`になり`openssl`コマンドがバージョンアップしたので、その部分だけはhttps://qiita.com/yyu/items/e0ed267df132795b7a5a 👈 こちらを参照する